### PR TITLE
Bug synchro child parent ctrlers

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
 <script src="js/utils.js"></script>
 
 <script src="js/makerscience/base/controllers.js"></script>
+<script src="js/makerscience/base/services.js"></script>
 <script src="js/makerscience/catalog/controllers.js"></script>
 <script src="js/makerscience/catalog/directives.js"></script>
 <script src="js/makerscience/catalog/services.js"></script>

--- a/js/src/app.coffee
+++ b/js/src/app.coffee
@@ -180,17 +180,17 @@ angular.module('makerscience', ['commons.catalog', 'commons.accounts', 'commons.
         )
 
 ])
-.run(($rootScope, editableOptions, editableThemes, amMoment, loginService, $state, $stateParams) ->
+.run(($rootScope, editableOptions, editableThemes, amMoment, loginService, $state, $stateParams, CurrentMakerScienceProfileService) ->
     editableOptions.theme = 'bs3'
     editableThemes['bs3'].submitTpl = '<button type="submit" class="btn btn-primary">Enregistrer</button>'
     editableThemes['bs3'].cancelTpl = '<button type="button" class="btn btn-default" ng-click="$form.$cancel()">Annuler</button>'
 
     amMoment.changeLocale('fr');
-
     $rootScope.loginService = loginService
     $rootScope.config = config
     $rootScope.$state = $state
     $rootScope.$stateParams = $stateParams
+    $rootScope.CurrentMakerScienceProfileService = CurrentMakerScienceProfileService
 
     $rootScope.Math = window.Math
 )

--- a/js/src/app.coffee
+++ b/js/src/app.coffee
@@ -3,7 +3,7 @@ angular.module('commons.accounts', ['commons.accounts.services', 'commons.accoun
 angular.module('commons.ucomment', ['commons.ucomment.controllers', 'commons.ucomment.services'])
 angular.module('makerscience.catalog', ['makerscience.catalog.controllers', 'makerscience.catalog.services', 'makerscience.catalog.directives'])
 angular.module('makerscience.profile', ['makerscience.profile.controllers', 'makerscience.profile.services'])
-angular.module('makerscience.base', ['makerscience.base.controllers'])
+angular.module('makerscience.base', ['makerscience.base.controllers', 'makerscience.base.services'])
 angular.module('makerscience.map', ['makerscience.map.controllers'])
 angular.module('makerscience', ['commons.catalog', 'commons.accounts', 'commons.ucomment', 'makerscience.catalog', 'makerscience.profile', 'makerscience.base','makerscience.map',
                                 'restangular', 'ui.bootstrap', 'ui.router', 'xeditable', 'textAngular', 'angularjs-gravatardirective', 'angularFileUpload',

--- a/js/src/commons/accounts/controllers.coffee
+++ b/js/src/commons/accounts/controllers.coffee
@@ -67,17 +67,16 @@ module.controller("CommunityCtrl", ($scope, Profile, ObjectProfileLink, DataShar
                 )
 
         $scope.objectTypeName = objectTypeName
-        #$scope.object = args[objectTypeName]
         console.log(" Shared Object ? ", DataSharing.sharedObject)
-        # assign it right away ( if parent ctrler has already rendered, we get it NOW)
-        $scope.object = DataSharing.sharedObject
-        # AND watch changes (if parent ctrl has not yet rendered, we WILL get it)
-        $scope.$watch('DataSharing.sharedObject', (newVal, oldVal, scope) ->
-            if newVal
-                console.log(" Updating Shared Object ", newVal)
-                $scope.object = newVal
-                $scope.community = ObjectProfileLink.one().customGETLIST($scope.objectTypeName+'/'+$scope.object.id).$object
+        $scope.$watch(()->
+                return DataSharing.sharedObject
+            ,(newVal, oldVal) ->
+                console.log(" Updating Shared Object : new ="+newVal+" old = "+oldVal)
+                if newVal != oldVal
+                    $scope.object = newVal[$scope.objectTypeName]
+                    $scope.community = ObjectProfileLink.one().customGETLIST($scope.objectTypeName+'/'+$scope.object.id).$object
         )
+        $scope.object = DataSharing.sharedObject[$scope.objectTypeName]
         if $scope.object
             $scope.community = ObjectProfileLink.one().customGETLIST($scope.objectTypeName+'/'+$scope.object.id).$object
         #)

--- a/js/src/commons/accounts/controllers.coffee
+++ b/js/src/commons/accounts/controllers.coffee
@@ -1,6 +1,6 @@
-module = angular.module("commons.accounts.controllers", ['commons.accounts.services'])
+module = angular.module("commons.accounts.controllers", ['commons.accounts.services', 'makerscience.base.services'])
 
-module.controller("CommunityCtrl", ($scope, Profile, ObjectProfileLink) ->
+module.controller("CommunityCtrl", ($scope, Profile, ObjectProfileLink, DataSharing) ->
     """
     Controller pour la manipulation des data d'une communauté liée à un objet partagé (project, fiche resource, etc.    )
     La sémantique des niveaux d'implication est à préciser en fonction de la resource.
@@ -18,56 +18,67 @@ module.controller("CommunityCtrl", ($scope, Profile, ObjectProfileLink) ->
 
     $scope.init = (objectTypeName) ->
 
-        $scope.$on(objectTypeName+'Ready', (event, args) ->
-            $scope.addMember = (profile, level, detail, isValidated)->
-                if $scope.isAlreadyMember(profile, level)
-                    console.log(" --- ! -- already Member with this level --- ! ---")
-                    return true
-                ObjectProfileLink.one().customPOST(
-                    profile_id: profile.id,
-                    level: level,
-                    detail : detail,
-                    isValidated:isValidated
-                , $scope.objectTypeName+'/'+$scope.object.id).then((objectProfileLinkResult) ->
-                    $scope.community.push(objectProfileLinkResult)
+        #$scope.$on(objectTypeName+'Ready', (event, args) ->
+        $scope.addMember = (profile, level, detail, isValidated)->
+            if $scope.isAlreadyMember(profile, level)
+                console.log(" --- ! -- already Member with this level --- ! ---")
+                return true
+            ObjectProfileLink.one().customPOST(
+                profile_id: profile.id,
+                level: level,
+                detail : detail,
+                isValidated:isValidated
+            , $scope.objectTypeName+'/'+$scope.object.id).then((objectProfileLinkResult) ->
+                $scope.community.push(objectProfileLinkResult)
+            )
+
+        $scope.isAlreadyMember = (profile, level)->
+            # Check if selected profile is not already added with given level
+            for member in $scope.community
+                if member.profile.resource_uri == profile.resource_uri
+                    if member.level == level
+                        return true
+            return false
+            
+        
+
+        $scope.removeMember = (member) ->
+            # attention confusion possible : member ici correspond à une instance de 
+            # ObjectProfileLink. L'id du profil concerné e.g se trouve à member.profile.id
+            ObjectProfileLink.one(member.id).remove().then(()->
+                memberIndex = $scope.community.indexOf(member)
+                $scope.community.splice(memberIndex, 1)
+            )
+
+        $scope.validateMember = ($event, member) ->
+            validated = $event.target.checked
+            console.log(" Validating ?? !", validated)
+            ObjectProfileLink.one(member.id).patch({isValidated : validated}).then(
+                memberIndex = $scope.community.indexOf(member)
+                member = $scope.community[memberIndex]
+                member.isValidated = validated
+                )
+        
+        $scope.updateMemberDetail = (detail, member) ->
+            ObjectProfileLink.one(member.id).patch({detail : detail}).then(
+                memberIndex = $scope.community.indexOf(member)
+                member = $scope.community[memberIndex]
+                member.detail = detail
                 )
 
-            $scope.isAlreadyMember = (profile, level)->
-                # Check if selected profile is not already added with given level
-                for member in $scope.community
-                    if member.profile.resource_uri == profile.resource_uri
-                        if member.level == level
-                            return true
-                return false
-                
-            
-
-            $scope.removeMember = (member) ->
-                # attention confusion possible : member ici correspond à une instance de 
-                # ObjectProfileLink. L'id du profil concerné e.g se trouve à member.profile.id
-                ObjectProfileLink.one(member.id).remove().then(()->
-                    memberIndex = $scope.community.indexOf(member)
-                    $scope.community.splice(memberIndex, 1)
-                )
-
-            $scope.validateMember = ($event, member) ->
-                validated = $event.target.checked
-                console.log(" Validating ?? !", validated)
-                ObjectProfileLink.one(member.id).patch({isValidated : validated}).then(
-                    memberIndex = $scope.community.indexOf(member)
-                    member = $scope.community[memberIndex]
-                    member.isValidated = validated
-                    )
-            
-            $scope.updateMemberDetail = (detail, member) ->
-                ObjectProfileLink.one(member.id).patch({detail : detail}).then(
-                    memberIndex = $scope.community.indexOf(member)
-                    member = $scope.community[memberIndex]
-                    member.detail = detail
-                    )
-
-            $scope.objectTypeName = objectTypeName
-            $scope.object = args[objectTypeName]
-            $scope.community = ObjectProfileLink.one().customGETLIST($scope.objectTypeName+'/'+$scope.object.id).$object
+        $scope.objectTypeName = objectTypeName
+        #$scope.object = args[objectTypeName]
+        console.log(" Shared Object ? ", DataSharing.sharedObject)
+        # assign it right away ( if parent ctrler has already rendered, we get it NOW)
+        $scope.object = DataSharing.sharedObject
+        # AND watch changes (if parent ctrl has not yet rendered, we WILL get it)
+        $scope.$watch('DataSharing.sharedObject', (newVal, oldVal, scope) ->
+            if newVal
+                console.log(" Updating Shared Object ", newVal)
+                $scope.object = newVal
+                $scope.community = ObjectProfileLink.one().customGETLIST($scope.objectTypeName+'/'+$scope.object.id).$object
         )
+        if $scope.object
+            $scope.community = ObjectProfileLink.one().customGETLIST($scope.objectTypeName+'/'+$scope.object.id).$object
+        #)
 )

--- a/js/src/commons/accounts/controllers.coffee
+++ b/js/src/commons/accounts/controllers.coffee
@@ -68,7 +68,11 @@ module.controller("CommunityCtrl", ($scope, Profile, ObjectProfileLink, DataShar
 
         $scope.objectTypeName = objectTypeName
         console.log(" Shared Object ? ", DataSharing.sharedObject)
-        $scope.$watch(()->
+        $scope.object = DataSharing.sharedObject[$scope.objectTypeName]
+        if $scope.object
+            $scope.community = ObjectProfileLink.one().customGETLIST($scope.objectTypeName+'/'+$scope.object.id).$object
+        $scope.$watch(
+            ()->
                 return DataSharing.sharedObject
             ,(newVal, oldVal) ->
                 console.log(" Updating Shared Object : new ="+newVal+" old = "+oldVal)
@@ -76,8 +80,5 @@ module.controller("CommunityCtrl", ($scope, Profile, ObjectProfileLink, DataShar
                     $scope.object = newVal[$scope.objectTypeName]
                     $scope.community = ObjectProfileLink.one().customGETLIST($scope.objectTypeName+'/'+$scope.object.id).$object
         )
-        $scope.object = DataSharing.sharedObject[$scope.objectTypeName]
-        if $scope.object
-            $scope.community = ObjectProfileLink.one().customGETLIST($scope.objectTypeName+'/'+$scope.object.id).$object
         #)
 )

--- a/js/src/commons/ucomment/controllers.coffee
+++ b/js/src/commons/ucomment/controllers.coffee
@@ -1,19 +1,33 @@
-module = angular.module("commons.ucomment.controllers", ['commons.ucomment.services'])
+module = angular.module("commons.ucomment.controllers", ['commons.ucomment.services', 'makerscience.base.services'])
 
-module.controller("CommentCtrl", ($scope, $rootScope, Comment) ->
+module.controller("CommentCtrl", ($scope, $rootScope, Comment, DataSharing) ->
     """
-    controlling comments attached to a resource. Requires that parent scope has:
-    - $scope.comments
+    controlling comments attached to a resource. 
     """
 
     $scope.newcommentForm =
         text: ""
 
     $scope.init = (objectTypeName) ->
-        $scope.$on(objectTypeName+'Ready', (event, args) ->
-            $scope.objectTypeName = objectTypeName
-            $scope.object = args[objectTypeName]
+        # $scope.$on(objectTypeName+'Ready', (event, args) ->
+        #     $scope.objectTypeName = objectTypeName
+        #     $scope.object = args[objectTypeName]
+        #     $scope.refreshComments($scope.objectTypeName, $scope.object.id)
+        # )
+
+        $scope.objectTypeName = objectTypeName
+        console.log(" Shared Object ? ", DataSharing.sharedObject)
+        $scope.object = DataSharing.sharedObject[$scope.objectTypeName]
+        if $scope.object
             $scope.refreshComments($scope.objectTypeName, $scope.object.id)
+        $scope.$watch(
+            ()->
+                return DataSharing.sharedObject
+            ,(newVal, oldVal) ->
+                console.log(" Updating Shared Object : new ="+newVal+" old = "+oldVal)
+                if newVal != oldVal
+                    $scope.object = newVal[$scope.objectTypeName]
+                    $scope.refreshComments($scope.objectTypeName, $scope.object.id)
         )
 
     $scope.refreshComments = (objectTypeName, objectId) ->

--- a/js/src/makerscience/base/controllers.coffee
+++ b/js/src/makerscience/base/controllers.coffee
@@ -1,35 +1,5 @@
 module = angular.module("makerscience.base.controllers", ['makerscience.catalog.controllers', 'makerscience.profile.controllers', 'commons.accounts.controllers'])
 
-module.controller('CurrentMakerScienceProfileCtrl', ($scope, $rootScope, $modal, MakerScienceProfile) ->
-    $rootScope.$watch('authVars.user', (newValue, oldValue) ->
-        if newValue != oldValue
-            MakerScienceProfile.one().get({parent__user__id : $rootScope.authVars.user.id}).then((profileResult)->
-                $rootScope.currentMakerScienceProfile = profileResult.objects[0]
-            )
-    )
-
-    $rootScope.openSignupPopup = ->
-        modalInstance = $modal.open(
-            templateUrl: 'views/base/signupModal.html',
-            controller: 'SignupPopupCtrl'
-    )
-)
-
-module.controller('SignupPopupCtrl', ($scope, $rootScope, $modalInstance, $state, User) ->
-    $scope.register = ->
-        $scope.user.email = $scope.user.username
-        User.post($scope.user).then((userResult) ->
-            $rootScope.authVars.username = $scope.user.username
-            $rootScope.authVars.password = $scope.user.password
-            $rootScope.loginService.submit()
-            $rootScope.$watch('currentMakerScienceProfile', (newValue, oldValue) ->
-                if newValue != oldValue
-                    $modalInstance.close()
-                    $state.go("profile.detail", {id : $rootScope.currentMakerScienceProfile.id})
-
-            )
-        )
-)
 
 module.directive('username', ($q, $timeout, User) ->
     require: 'ngModel'

--- a/js/src/makerscience/base/services.coffee
+++ b/js/src/makerscience/base/services.coffee
@@ -1,0 +1,10 @@
+module = angular.module("makerscience.base.services", ['restangular'])
+
+class DataSharing
+        constructor: (@$rootScope) ->
+                @sharedObject = {}
+
+# Services
+module.factory('DataSharing', ($rootScope) ->
+    return new DataSharing($rootScope)
+)

--- a/js/src/makerscience/base/services.coffee
+++ b/js/src/makerscience/base/services.coffee
@@ -2,6 +2,7 @@ module = angular.module("makerscience.base.services", ['restangular'])
 
 class DataSharing
         constructor: (@$rootScope) ->
+                console.log("init DataSharing")
                 @sharedObject = {}
 
 # Services

--- a/js/src/makerscience/catalog/controllers.coffee
+++ b/js/src/makerscience/catalog/controllers.coffee
@@ -1,4 +1,4 @@
-module = angular.module("makerscience.catalog.controllers", ['makerscience.catalog.services', 'commons.graffiti.controllers', "commons.accounts.controllers"])
+module = angular.module("makerscience.catalog.controllers", ['makerscience.catalog.services', 'commons.graffiti.controllers', "commons.accounts.controllers", 'makerscience.base.services'])
 
 module.controller("MakerScienceProjectListCtrl", ($scope, MakerScienceProject) ->
     $scope.limit = 12
@@ -105,7 +105,7 @@ module.controller("MakerScienceProjectSheetCreateCtrl", ($scope, $state, $contro
         delete $scope.needs[index]
 )
 
-module.controller("MakerScienceProjectSheetCtrl", ($scope, $stateParams, $controller, MakerScienceProject, MakerScienceResource, TaggedItem, Comment, ObjectProfileLink) ->
+module.controller("MakerScienceProjectSheetCtrl", ($scope, $stateParams, $controller, MakerScienceProject, MakerScienceResource, TaggedItem, Comment, ObjectProfileLink, DataSharing) ->
     $controller('ProjectSheetCtrl', {$scope: $scope, $stateParams: $stateParams})
     $controller('TaggedItemCtrl', {$scope: $scope})
     $controller('MakerScienceLinkedResourceCtrl', {$scope: $scope})
@@ -116,6 +116,7 @@ module.controller("MakerScienceProjectSheetCtrl", ($scope, $stateParams, $contro
         $scope.projectsheet = makerScienceProjectResult.objects[0]
 
         $scope.$broadcast('projectReady', {project : $scope.projectsheet.parent})
+        DataSharing.sharedObject =  $scope.projectsheet.parent
         $scope.$broadcast('makerscienceprojectReady', {makerscienceproject : $scope.projectsheet})
 
         $scope.linkedResources = angular.copy($scope.projectsheet.linked_resources)
@@ -200,6 +201,7 @@ module.controller("MakerScienceResourceSheetCtrl", ($scope, $stateParams, $contr
 
         $scope.$broadcast('projectReady', {project : $scope.projectsheet.parent})
         $scope.$broadcast('makerscienceresourceReady', {makerscienceresource : $scope.projectsheet})
+        $scope.sharedObject = {project : $scope.projectsheet.parent, makerscienceresource : $scope.projectsheet}
 
         $scope.linkedResources = angular.copy($scope.projectsheet.linked_resources)
 

--- a/js/src/makerscience/catalog/controllers.coffee
+++ b/js/src/makerscience/catalog/controllers.coffee
@@ -115,11 +115,13 @@ module.controller("MakerScienceProjectSheetCtrl", ($scope, $stateParams, $contro
     MakerScienceProject.one().get({'parent__slug' : $stateParams.slug}).then((makerScienceProjectResult) ->
         $scope.projectsheet = makerScienceProjectResult.objects[0]
 
+        # FIXME : these 2 signals should be removed, since we now use DataSharing service
         $scope.$broadcast('projectReady', {project : $scope.projectsheet.parent})
-        console.log("before setting datasharing", DataSharing.sharedObject)
-        DataSharing.sharedObject =  {project: $scope.projectsheet.parent}
-        console.log("AFTER setting datasharing", DataSharing.sharedObject)
         $scope.$broadcast('makerscienceprojectReady', {makerscienceproject : $scope.projectsheet})
+        
+        console.log("before setting datasharing", DataSharing.sharedObject)
+        DataSharing.sharedObject =  {project: $scope.projectsheet.parent, makerscienceproject : $scope.projectsheet}
+        console.log("AFTER setting datasharing", DataSharing.sharedObject)
 
         $scope.linkedResources = angular.copy($scope.projectsheet.linked_resources)
 
@@ -191,7 +193,7 @@ module.controller("MakerScienceResourceSheetCreateCtrl", ($scope, $state, $contr
         )
 )
 
-module.controller("MakerScienceResourceSheetCtrl", ($scope, $stateParams, $controller, MakerScienceResource, TaggedItem, Comment) ->
+module.controller("MakerScienceResourceSheetCtrl", ($scope, $stateParams, $controller, MakerScienceResource, TaggedItem, Comment, DataSharing) ->
     $controller('ProjectSheetCtrl', {$scope: $scope, $stateParams: $stateParams})
     $controller('TaggedItemCtrl', {$scope: $scope})
     $controller('MakerScienceLinkedResourceCtrl', {$scope: $scope})
@@ -201,9 +203,13 @@ module.controller("MakerScienceResourceSheetCtrl", ($scope, $stateParams, $contr
     MakerScienceResource.one().get({'parent__slug' : $stateParams.slug}).then((makerScienceResourceResult) ->
         $scope.projectsheet = $scope.resourcesheet = makerScienceResourceResult.objects[0]
 
+        # FIXME : remove 2 signals below, > now using service + $watch to share and sync data
         $scope.$broadcast('projectReady', {project : $scope.projectsheet.parent})
         $scope.$broadcast('makerscienceresourceReady', {makerscienceresource : $scope.projectsheet})
-        $scope.sharedObject = {project : $scope.projectsheet.parent, makerscienceresource : $scope.projectsheet}
+        
+        console.log("before setting datasharing", DataSharing.sharedObject)
+        DataSharing.sharedObject =  {project : $scope.projectsheet.parent, makerscienceresource : $scope.projectsheet}
+        console.log("AFTER setting datasharing", DataSharing.sharedObject)
 
         $scope.linkedResources = angular.copy($scope.projectsheet.linked_resources)
 

--- a/js/src/makerscience/catalog/controllers.coffee
+++ b/js/src/makerscience/catalog/controllers.coffee
@@ -116,7 +116,9 @@ module.controller("MakerScienceProjectSheetCtrl", ($scope, $stateParams, $contro
         $scope.projectsheet = makerScienceProjectResult.objects[0]
 
         $scope.$broadcast('projectReady', {project : $scope.projectsheet.parent})
-        DataSharing.sharedObject =  $scope.projectsheet.parent
+        console.log("before setting datasharing", DataSharing.sharedObject)
+        DataSharing.sharedObject =  {project: $scope.projectsheet.parent}
+        console.log("AFTER setting datasharing", DataSharing.sharedObject)
         $scope.$broadcast('makerscienceprojectReady', {makerscienceproject : $scope.projectsheet})
 
         $scope.linkedResources = angular.copy($scope.projectsheet.linked_resources)

--- a/js/src/makerscience/profile/services.coffee
+++ b/js/src/makerscience/profile/services.coffee
@@ -1,7 +1,6 @@
 module = angular.module("makerscience.profile.services", [])
 
-
-# Services
+# Restangular-based Services
 module.factory('MakerScienceProfile', (Restangular) ->
     return Restangular.service('makerscience/profile')
 )
@@ -9,3 +8,49 @@ module.factory('MakerScienceProfile', (Restangular) ->
 module.factory('MakerScienceProfileTaggedItem', (Restangular) ->
     return Restangular.service('makerscience/profiletaggeditem')
 )
+
+# Specific services
+#module.controller('CurrentMakerScienceProfileCtrl', 
+class CurrentMakerScienceProfileService 
+    constructor : ($rootScope, $modal, MakerScienceProfile) ->
+        $rootScope.openSignupPopup = this.openSignupPopup
+        
+        $rootScope.$watch('authVars.user', (newValue, oldValue) ->
+            if newValue != oldValue
+                MakerScienceProfile.one().get({parent__user__id : $rootScope.authVars.user.id}).then((profileResult)->
+                    $rootScope.currentMakerScienceProfile = profileResult.objects[0]
+                )
+        )
+
+    openSignupPopup : ()->
+        modalInstance = $modal.open(
+            templateUrl: 'views/base/signupModal.html',
+            controller: 'SignupPopupCtrl'
+        )
+
+
+module.factory('CurrentMakerScienceProfileService', ($rootScope, $modal, MakerScienceProfile) ->
+    return new CurrentMakerScienceProfileService($rootScope, $modal, MakerScienceProfile)
+)
+  
+
+module.controller('SignupPopupCtrl', ($scope, $rootScope, $modalInstance, $state, User) ->
+    """
+    Controller bound to openSignupPopup method of CurrentMakerScienceProfile service
+    """
+    $scope.register = ->
+        $scope.user.email = $scope.user.username
+        User.post($scope.user).then((userResult) ->
+            $rootScope.authVars.username = $scope.user.username
+            $rootScope.authVars.password = $scope.user.password
+            $rootScope.loginService.submit()
+            $rootScope.$watch('currentMakerScienceProfile', (newValue, oldValue) ->
+                if newValue != oldValue
+                    $modalInstance.close()
+                    $state.go("profile.detail", {id : $rootScope.currentMakerScienceProfile.id})
+
+            )
+        )
+)
+
+

--- a/js/src/makerscience/profile/services.coffee
+++ b/js/src/makerscience/profile/services.coffee
@@ -1,4 +1,4 @@
-module = angular.module("makerscience.profile.services", [])
+module = angular.module("makerscience.profile.services", ['commons.accounts.services'])
 
 # Restangular-based Services
 module.factory('MakerScienceProfile', (Restangular) ->
@@ -13,8 +13,7 @@ module.factory('MakerScienceProfileTaggedItem', (Restangular) ->
 #module.controller('CurrentMakerScienceProfileCtrl', 
 class CurrentMakerScienceProfileService 
     constructor : ($rootScope, $modal, MakerScienceProfile) ->
-        $rootScope.openSignupPopup = this.openSignupPopup
-        
+
         $rootScope.$watch('authVars.user', (newValue, oldValue) ->
             if newValue != oldValue
                 MakerScienceProfile.one().get({parent__user__id : $rootScope.authVars.user.id}).then((profileResult)->
@@ -22,11 +21,11 @@ class CurrentMakerScienceProfileService
                 )
         )
 
-    openSignupPopup : ()->
-        modalInstance = $modal.open(
-            templateUrl: 'views/base/signupModal.html',
-            controller: 'SignupPopupCtrl'
-        )
+        $rootScope.openSignupPopup = ()->
+            modalInstance = $modal.open(
+                templateUrl: 'views/base/signupModal.html',
+                controller: 'SignupPopupCtrl'
+            )
 
 
 module.factory('CurrentMakerScienceProfileService', ($rootScope, $modal, MakerScienceProfile) ->

--- a/views/base/header.html
+++ b/views/base/header.html
@@ -1,4 +1,4 @@
-<div id="header" ng-controller="CurrentMakerScienceProfileCtrl">
+<div id="header">
 
     <header id="fixed-nav" data-spy="affix">
         <nav id="menu" class="navbar" role="navigation">


### PR DESCRIPTION
Pb was: child controller listen to event from parent ctrller, but when child ctrler is init *after* parent, the signal does not get caught.
> Sol for community and comment ctrl with regard to MakerScience[Project | Resource]SheetCtrl is: 
- use DataSharing service that is injected into both child and parent ctrler 
- parent ctrl set DataSharing var (sharedObject)
- child ctrl read this var and watch for changes in case parent ctrler is init *after* child ctrler

> Sol for currentMakerScienceProfileCtrl was to make it a service init by main app 